### PR TITLE
[FIX] 로그인 후 권한 없음에 대한 버그 픽스

### DIFF
--- a/src/main/java/com/intouch/aligooligo/Jwt/JwtTokenProvider.java
+++ b/src/main/java/com/intouch/aligooligo/Jwt/JwtTokenProvider.java
@@ -46,7 +46,7 @@ public class JwtTokenProvider {
     public TokenInfo createToken(String userPk, Role roles) {
         log.info("createToken 시작");
         Claims claims = Jwts.claims().setSubject(userPk); // JWT payload 에 저장되는 정보단위
-        claims.put("roles", roles.name()); // 정보는 key / value 쌍으로 저장된다.
+        claims.put("roles", "ROLE_" + roles.name()); // 정보는 key / value 쌍으로 저장된다.
         Date now = new Date();
         long accessTokenValidTime = now.getTime() + 180 * 60 * 1000L;
         long refreshTokenValidTime = now.getTime() + 14 * 24 * 60 * 60 * 1000L;


### PR DESCRIPTION
- spring security에서 hasRole은 스트링 앞에 prefix로 ROLE_이 자동으로 붙음.
- 예시로 hasRole("USER") 이면 자동으로 ROLE_USER이 됨.
- 따라서 권한을 맞추기 위해 토큰에 집어넣었던 일반 USER에서 ROLE_을 prefix로 붙여주어 해결