### PR TITLE
[REFACTOR] jwt인증필터 수정

### DIFF
--- a/src/main/java/com/intouch/aligooligo/Jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/intouch/aligooligo/Jwt/JwtAuthenticationFilter.java
@@ -8,35 +8,50 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.PatternMatchUtils;
 import org.springframework.web.filter.GenericFilterBean;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
-public class JwtAuthenticationFilter extends GenericFilterBean {
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
 
-    @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        // 헤더에서 JWT 를 받아옵니다.
-        try {
-            String token = jwtTokenProvider.resolveAccessToken((HttpServletRequest) request);
-            // 유효한 토큰인지 확인합니다.
+    private static final String[] whiteList = {
+            "/api/auth/**", "/api/seed/share/**",
+            "/swagger-ui/**", "/api-docs/**"
+    };
 
-            if (token != null && !token.equals("null") && jwtTokenProvider.validateToken(token)) {
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return PatternMatchUtils.simpleMatch(whiteList, request.getRequestURI());
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        log.info("jwtAuthenticationFilter");
+        try {
+            String token = jwtTokenProvider.resolveAccessToken(request);
+
+            if (token != null && jwtTokenProvider.validateToken(token)) {
                 // 토큰이 유효하면 토큰으로부터 유저 정보를 받아옵니다.
                 Authentication authentication = jwtTokenProvider.getAuthentication(token);
                 // SecurityContext 에 Authentication 객체를 저장합니다.
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
-        }catch (JwtException e){
+        } catch (JwtException e){
             JwtErrorResponse((HttpServletResponse) response, e.getMessage());
             return;
         }
-        chain.doFilter(request, response);
+        filterChain.doFilter(request, response);
+
     }
 
     private void JwtErrorResponse(HttpServletResponse response, String msg) throws IOException{


### PR DESCRIPTION
- shouldNotFilter도입을 통해 특정 API(ex. 로그인) jwt 필터 무시
- string "null" 일치 조건 제거를 통해 "bearer null"에 대한 처리 제거
- "bearer null"에 대한 처리는 프론트에서 할 예정