### PR TITLE
[REFACTOR] 응원하기 API 호출될때마다 자동으로 상태값을 반대로 변하게 수정

### DIFF
--- a/src/main/java/com/intouch/aligooligo/User/Controller/UserController.java
+++ b/src/main/java/com/intouch/aligooligo/User/Controller/UserController.java
@@ -4,6 +4,7 @@ import com.intouch.aligooligo.Jwt.JwtTokenProvider;
 import com.intouch.aligooligo.User.Entity.Role;
 import com.intouch.aligooligo.User.Entity.User;
 import com.intouch.aligooligo.User.Repository.UserRepository;
+import com.intouch.aligooligo.auth.dto.SignInResponse;
 import com.intouch.aligooligo.auth.dto.TokenInfo;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,12 +21,10 @@ public class UserController {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtProvider;
     @PostMapping
-    public ResponseEntity<?> login(@RequestParam("email") String admin) {
-        User user = userRepository.findByEmail(admin).get();
-        TokenInfo tokenInfo = null;
-        if(user.getEmail().equals(admin)) {
-            tokenInfo = jwtProvider.createToken(admin, Role.USER);
-        }
-        return new ResponseEntity<>(tokenInfo, HttpStatus.OK);
+    public ResponseEntity<?> login() {
+        User user = userRepository.findByEmail("admin").get();
+        TokenInfo tokenInfo = jwtProvider.createToken(user.getEmail(), Role.USER);
+
+        return new ResponseEntity<>(new SignInResponse(tokenInfo, false), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/intouch/aligooligo/seed/controller/SeedController.java
+++ b/src/main/java/com/intouch/aligooligo/seed/controller/SeedController.java
@@ -157,23 +157,16 @@ public class SeedController {
     }
 
     @PatchMapping("/{id}/cheer")
-    @Operation(summary = "응원하기(좋아요) 증가/감소", description = "특정 seed의 좋아요를 증가/감소시킨다. 응원중인 씨앗에"
-            + "재 요청이 왔을 때는 Http 200과 message로 \"이미 응원중인 씨앗입니다\" 문구가 출력. "
-            + "이에 따라 재 요청 시 감소하도록 프론트 로직을 처리할 수 있다. , 인증된 사용자만 접근 가능")
+    @Operation(summary = "응원하기(좋아요) 증가/감소", description = "특정 seed의 좋아요를 증가/감소시킨다, 인증된 사용자만 접근 가능")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "1. 증가 성공\t\n 2. 이미 응원중인 씨앗일 때"),
             @ApiResponse(responseCode = "500", description = "기타 서버 에러",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorMessage.class)))
     })
-    public ResponseEntity<?> increaseLike(@PathVariable("id") Long seedId, @RequestParam Boolean isIncreased) {
+    public ResponseEntity<?> increaseCheer(@PathVariable("id") Long seedId) {
         try{
-            if (isIncreased) {
-                seedService.increaseLike(seedId);
-            }
-            else {
-                seedService.decreaseLike(seedId);
-            }
+            seedService.mediateCheer(seedId);
             return new ResponseEntity<>(HttpStatus.OK);
         } catch (IllegalArgumentException e) {
             return new ResponseEntity<>(new ErrorMessage(ErrorMessageDescription.ALREADY_EXIST_LIKE.getDescription()), HttpStatus.OK);

--- a/src/main/java/com/intouch/aligooligo/seed/controller/dto/request/CreateSeedRequest.java
+++ b/src/main/java/com/intouch/aligooligo/seed/controller/dto/request/CreateSeedRequest.java
@@ -1,6 +1,8 @@
 package com.intouch.aligooligo.seed.controller.dto.request;
 
 import com.intouch.aligooligo.seed.controller.dto.RoutineInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,7 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class CreateSeedRequest {
-    private String endDate;
+    private LocalDateTime endDate;
     private String seed;
     private List<RoutineInfo> routines;
 }

--- a/src/main/java/com/intouch/aligooligo/seed/controller/dto/response/SeedDetailResponse.java
+++ b/src/main/java/com/intouch/aligooligo/seed/controller/dto/response/SeedDetailResponse.java
@@ -1,6 +1,7 @@
 package com.intouch.aligooligo.seed.controller.dto.response;
 
 import com.intouch.aligooligo.seed.domain.Cheering;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -15,8 +16,8 @@ import lombok.ToString;
 public class SeedDetailResponse {
     private Long id;
     private String seedName;
-    private String startDate;
-    private String endDate;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
     private Integer completedRoutineCount;
     private String seedState;
     private List<RoutineDetail> routineDetails;

--- a/src/main/java/com/intouch/aligooligo/seed/controller/dto/response/SeedListResponse.java
+++ b/src/main/java/com/intouch/aligooligo/seed/controller/dto/response/SeedListResponse.java
@@ -4,6 +4,7 @@ package com.intouch.aligooligo.seed.controller.dto.response;
 import com.intouch.aligooligo.seed.controller.dto.RoutineInfo;
 import com.intouch.aligooligo.seed.domain.Routine;
 import com.intouch.aligooligo.seed.domain.Seed;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -29,8 +30,8 @@ public class SeedListResponse {
     @AllArgsConstructor
     private static class SeedInfo {
         private Long id;
-        private String startDate;
-        private String endDate;
+        private LocalDateTime startDate;
+        private LocalDateTime endDate;
         private String seedName;
         private List<RoutineInfo> routineInfos;
         private Integer completedRoutineCount;
@@ -62,8 +63,8 @@ public class SeedListResponse {
     public void updateSeedList(Page<Seed> seedList, List<List<Routine>> routinesList, Long cheeringCount, List<Integer> completedRoutineCountList) {
         List<Seed> seeds = seedList.getContent();
         for (int i = 0; i < seeds.size(); i++) {
-            String seedStartDate = seeds.get(i).getStartDate().toString();
-            String seedEndDate = seeds.get(i).getEndDate().toString();
+            LocalDateTime seedStartDate = seeds.get(i).getStartDate();
+            LocalDateTime seedEndDate = seeds.get(i).getEndDate();
             Integer completedRoutineCount = completedRoutineCountList.get(i);
 
             List<Routine> routines = routinesList.get(i);

--- a/src/main/java/com/intouch/aligooligo/seed/controller/dto/response/SeedSharedResponse.java
+++ b/src/main/java/com/intouch/aligooligo/seed/controller/dto/response/SeedSharedResponse.java
@@ -1,5 +1,6 @@
 package com.intouch.aligooligo.seed.controller.dto.response;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,8 +12,8 @@ import lombok.Getter;
 public class SeedSharedResponse {
     private Long id;
     private String seedName;
-    private String startDate;
-    private String endDate;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
     private Integer completedRoutineCount;
     private String seedState;
     private List<SharedRoutineDetail> routineDetails;

--- a/src/main/java/com/intouch/aligooligo/seed/service/SeedService.java
+++ b/src/main/java/com/intouch/aligooligo/seed/service/SeedService.java
@@ -99,8 +99,7 @@ public class SeedService {
                 });
 
         LocalDateTime startDate = LocalDateTime.now(Clock.systemDefaultZone());
-        LocalDateTime endDate = LocalDate.parse(createSeedRequest.getEndDate())
-                .plusDays(1).atStartOfDay().minusNanos(1);
+        LocalDateTime endDate = createSeedRequest.getEndDate().plusDays(1).minusNanos(1);
         Seed seed = seedRepository.save(Seed.builder().startDate(startDate).endDate(endDate)
                 .seed(createSeedRequest.getSeed()).state(SeedState.SEED.name()).user(user).build());
 
@@ -137,7 +136,7 @@ public class SeedService {
         Integer completedRoutineCount = getCompletedRoutineCount(routines);
 
         return SeedDetailResponse.builder().id(seed.getId()).seedName(seed.getSeed())
-                .startDate(String.valueOf(seed.getStartDate())).endDate(String.valueOf(seed.getEndDate()))
+                .startDate(seed.getStartDate()).endDate(seed.getEndDate())
                 .completedRoutineCount(completedRoutineCount).routineDetails(routineDetails)
                 .seedState(seed.getState()).cheerUserCount(cheerUserCount).build();
     }
@@ -158,7 +157,7 @@ public class SeedService {
         Integer completedRoutineCount = getCompletedRoutineCount(routines);
 
         return SeedSharedResponse.builder().id(seedId).seedName(seed.getSeed())
-                .startDate(String.valueOf(seed.getStartDate())).endDate(String.valueOf(seed.getEndDate()))
+                .startDate(seed.getStartDate()).endDate(seed.getEndDate())
                 .completedRoutineCount(completedRoutineCount).routineDetails(sharedRoutineDetails)
                 .seedState(seed.getState()).cheerUserCount(cheerUserCount).build();
     }

--- a/src/main/java/com/intouch/aligooligo/seed/service/SeedService.java
+++ b/src/main/java/com/intouch/aligooligo/seed/service/SeedService.java
@@ -241,20 +241,15 @@ public class SeedService {
     }
 
     @Transactional
-    public void increaseLike(Long seedId) {
+    public void mediateCheer(Long seedId) {
         Seed seed = seedRepository.findById(seedId)
                 .orElseThrow(() -> new IllegalArgumentException(ErrorMessageDescription.SEED_NOT_FOUND.getDescription()));
         if (cheeringRepository.existsBySeedIdAndUserId(seed.getId(), seed.getUser().getId())) {
-            throw new IllegalArgumentException("이미 응원중인 씨앗입니다.");
+            cheeringRepository.deleteBySeedIdAndUserId(seed.getId(), seed.getUser().getId());
         }
-        cheeringRepository.save(new Cheering(seed, seed.getUser()));
-    }
-
-    @Transactional
-    public void decreaseLike(Long seedId) {
-        Seed seed = seedRepository.findById(seedId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorMessageDescription.SEED_NOT_FOUND.getDescription()));
-        cheeringRepository.deleteBySeedIdAndUserId(seed.getId(), seed.getUser().getId());
+        else {
+            cheeringRepository.save(new Cheering(seed, seed.getUser()));
+        }
     }
 
     public CheerInfo getCheeringInfo(Long seedId) {


### PR DESCRIPTION
- 요청, 응답 구조중 날짜 데이터 string -> datetime으로 변경
- 로그인 반환 값 수정, 이제 쿼리 파라미터 불필요