### PR TITLE
[FIX] 응원하는 유저가 있어도 리스트 조회에 응원 유저 수가 없는 버그 수정

### DIFF
--- a/src/main/java/com/intouch/aligooligo/seed/controller/dto/response/SeedListResponse.java
+++ b/src/main/java/com/intouch/aligooligo/seed/controller/dto/response/SeedListResponse.java
@@ -60,13 +60,13 @@ public class SeedListResponse {
         return routineInfos;
     }
 
-    public void updateSeedList(Page<Seed> seedList, List<List<Routine>> routinesList, Long cheeringCount, List<Integer> completedRoutineCountList) {
+    public void updateSeedList(Page<Seed> seedList, List<List<Routine>> routinesList, List<Long> cheeringCountList, List<Integer> completedRoutineCountList) {
         List<Seed> seeds = seedList.getContent();
         for (int i = 0; i < seeds.size(); i++) {
             LocalDateTime seedStartDate = seeds.get(i).getStartDate();
             LocalDateTime seedEndDate = seeds.get(i).getEndDate();
             Integer completedRoutineCount = completedRoutineCountList.get(i);
-
+            Long cheeringCount = cheeringCountList.get(i);
             List<Routine> routines = routinesList.get(i);
 
             SeedInfo newSeedInfo = new SeedInfo(

--- a/src/main/java/com/intouch/aligooligo/seed/service/SeedService.java
+++ b/src/main/java/com/intouch/aligooligo/seed/service/SeedService.java
@@ -67,18 +67,19 @@ public class SeedService {
 
         List<Integer> completedRoutineCountList = new ArrayList<>();
         List<List<Routine>> routinesList = new ArrayList<>();
-        long cheeringCount = 0;
+        List<Long> cheeringCountList = new ArrayList<>();
 
         for (Seed seed : seedList) {
             List<Routine> routines = routineRepository.findBySeedId(seed.getId());
-            cheeringCount = cheeringRepository.countBySeedId(seed.getId());
+            long cheeringCount = cheeringRepository.countBySeedId(seed.getId());
             Integer completedRoutineCount = getCompletedRoutineCount(routines);
             routinesList.add(routines);
             completedRoutineCountList.add(completedRoutineCount);
+            cheeringCountList.add(cheeringCount);
         }
 
         SeedListResponse listResponse = new SeedListResponse();
-        listResponse.updateSeedList(seedList, routinesList, cheeringCount, completedRoutineCountList);
+        listResponse.updateSeedList(seedList, routinesList, cheeringCountList, completedRoutineCountList);
         listResponse.updatePages(seedList);
 
         return listResponse;


### PR DESCRIPTION
- for문을 순회하는데 유저 수를 구하고 저장을 안해놓아서 생긴 문제
- 리스트에 저장하여 인덱스로 접근하여 문제 해결